### PR TITLE
ward/links

### DIFF
--- a/client/register.coffee
+++ b/client/register.coffee
@@ -66,6 +66,7 @@ submit = ($item, item) ->
 
 emit = ($item, item) ->
   $item.html form item
+  port = if (window.location.port) then ':' + window.location.port else ''
   $item.find('button.existing').click ->
     fetch('/plugin/register/using')
       .then (res) ->
@@ -76,7 +77,7 @@ emit = ($item, item) ->
       .then (list) ->
         html = list.map (item) ->
           # "#{item.site} (#{if item.owned then 'mine' else 'others'})"
-          "<a href=//#{item.site}>#{item.site}</a>"
+          "<a href=//#{item.site}#{port}>#{item.site}</a>"
         if !html.length then html = ['<i>no subdomains here</i>']
         html.unshift('<br>')
         $item.find('span.existing').html(html.join("<br>"))
@@ -85,7 +86,7 @@ emit = ($item, item) ->
   $item.find('span.existing, a').click ->
     event.preventDefault()
     page = $item.parents '.page' unless event.shiftKey
-    wiki.doInternalLink 'welcome-visitors',page,event.target.innerText
+    wiki.doInternalLink 'welcome-visitors',page,event.target.innerText+port
 
 bind = ($item, item) ->
   $item.dblclick -> wiki.textEditor $item, item

--- a/client/register.coffee
+++ b/client/register.coffee
@@ -1,4 +1,3 @@
-
 expand = (text) ->
   text
     .replace /&/g, '&amp;'
@@ -77,12 +76,16 @@ emit = ($item, item) ->
       .then (list) ->
         html = list.map (item) ->
           # "#{item.site} (#{if item.owned then 'mine' else 'others'})"
-          item.site
+          "<a href=//#{item.site}>#{item.site}</a>"
         if !html.length then html = ['<i>no subdomains here</i>']
         html.unshift('<br>')
         $item.find('span.existing').html(html.join("<br>"))
   $item.find('button.register').click ->
     submit $item, item
+  $item.find('span.existing, a').click ->
+    event.preventDefault()
+    page = $item.parents '.page' unless event.shiftKey
+    wiki.doInternalLink 'welcome-visitors',page,event.target.innerText
 
 bind = ($item, item) ->
   $item.dblclick -> wiki.textEditor $item, item

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki-plugin-register",
-  "version": "0.3.0-exp7",
+  "version": "0.3.1",
   "description": "Federated Wiki - Register Plugin",
   "keywords": [
     "register",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki-plugin-register",
-  "version": "0.3.0-exp5",
+  "version": "0.3.0-exp7",
   "description": "Federated Wiki - Register Plugin",
   "keywords": [
     "register",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki-plugin-register",
-  "version": "0.3.1",
+  "version": "0.3.0",
   "description": "Federated Wiki - Register Plugin",
   "keywords": [
     "register",


### PR DESCRIPTION
I've added links for existing sites which I handle with wiki.doInternalLink.

<img width="434" alt="image" src="https://user-images.githubusercontent.com/12127/169172712-137a58e7-cf99-4dfb-976f-2270e87afc3d.png">

These links are intended to open the welcome-visitors page. This works when the page exists. It also sometimes works when not. Here is what I observe.

If the empty site has a flag, it will open on the default for welcome-visitors.
if the empty site does not have a flag, our new default, then we get the page does not exist for the current site.

It is unfortunate that we have this dependency on the new site having a flag. The defaulting of the flag must be bypassed by wiki.doInternalLink. With debugger open this case fails inside of testWikiSite. This must be part of our protocol probing?

<img width="1738" alt="image" src="https://user-images.githubusercontent.com/12127/169173891-a472acb6-b6fe-423d-af96-c5f437e513de.png">

A work around might be for the server side to check for the flag or for the welcome-vistors page, or both, and not offer to link otherwise.

Aside: It is very tempting to set a new flag for a new site. I tried this for a brand new site and accidentally clobbered my oldest and favorite flag. Good news, I was able to save my old flag by viewing and downloading the flag from another tab. These were the colors present in the background image on the laptop I was using at the time. They are the colors of early morning in Venice Beach, California.

![favicon](https://user-images.githubusercontent.com/12127/169174382-aa1c57bf-096c-4e0a-bb4a-77f9ebd0651f.png)




