### PR TITLE
new endpoints for custom registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki-plugin-register",
-  "version": "0.5.0-pre3",
+  "version": "0.5.0-pre4",
   "description": "Federated Wiki - Register Plugin",
   "keywords": [
     "register",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki-plugin-register",
-  "version": "0.5.0-pre2",
+  "version": "0.5.0-pre3",
   "description": "Federated Wiki - Register Plugin",
   "keywords": [
     "register",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki-plugin-register",
-  "version": "0.5.0-pre4",
+  "version": "0.5.0-pre6",
   "description": "Federated Wiki - Register Plugin",
   "keywords": [
     "register",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki-plugin-register",
-  "version": "0.4.0",
+  "version": "0.5.0-pre1",
   "description": "Federated Wiki - Register Plugin",
   "keywords": [
     "register",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki-plugin-register",
-  "version": "0.5.0-pre1",
+  "version": "0.5.0-pre2",
   "description": "Federated Wiki - Register Plugin",
   "keywords": [
     "register",

--- a/server/server.coffee
+++ b/server/server.coffee
@@ -165,11 +165,11 @@ startServer = (params) ->
       return e400 status if err
       res.status(200).send(status)
 
-  app.get '/plugin/register/custom', farm, owner, (req, res) ->
+  app.get '/plugin/register/custom', farm, (req, res) ->
     e400 = (msg) -> res.status(400).send(msg)
     e501 = (msg) -> res.status(501).send(msg)
     return e501 "No register module" unless custom
-    custom.get argv, (err,status) ->
+    custom.get argv, req.query.domain, (err,status) ->
       return e400 err if err
       res.status(200).send(status)
 

--- a/server/server.coffee
+++ b/server/server.coffee
@@ -150,13 +150,23 @@ startServer = (params) ->
 
   # C U S T O M
 
-  app.post '/plugin/register/custom', farm, (req, res) ->
-    e500 = (msg) -> res.status(500).send(msg)
-    return e500 "No post logic yet"
+  custom = null
+  fs.readFile "#{argv.status}/register.js", 'utf8', (err, module) ->
+    custom = await import("data:text/javascript;base64,#{btoa(module)}")
 
-  app.get '/plugin/register/custom', farm, owner, (req, res) ->
-    e500 = (msg) -> res.status(500).send(msg)
-    return e500 "No get logic yet"
+  app.post '/plugin/register/custom', farm, (req, res) ->
+    e400 = (msg) -> res.status(400).send(msg)
+    e501 = (msg) -> res.status(501).send(msg)
+    return e400 "Missing data" unless data = req.body.data
+    return e400 "Missing context" unless context =req.body.context
+    console.log('custom post',{context,data,custom})
+    return e501 "No register module" unless custom
+    return await custom.post(data)
+
+  app.get '/plugin/register/custom', farm, (req, res) ->
+    e501 = (msg) -> res.status(501).send(msg)
+    console.log(req)
+    return e501 "No get logic yet"
 
 
 module.exports = {startServer}

--- a/server/server.coffee
+++ b/server/server.coffee
@@ -169,7 +169,7 @@ startServer = (params) ->
     e400 = (msg) -> res.status(400).send(msg)
     e501 = (msg) -> res.status(501).send(msg)
     return e501 "No register module" unless custom
-    custom.get argv, req.query.domain, (err,status) ->
+    custom.get argv, req, (err,status) ->
       return e400 err if err
       res.status(200).send(status)
 

--- a/server/server.coffee
+++ b/server/server.coffee
@@ -148,5 +148,15 @@ startServer = (params) ->
         res.json(payload)
 
 
+  # C U S T O M
+
+  app.post '/plugin/register/custom', farm, (req, res) ->
+    e500 = (msg) -> res.status(500).send(msg)
+    return e500 "No post logic yet"
+
+  app.get '/plugin/register/custom', farm, owner, (req, res) ->
+    e500 = (msg) -> res.status(500).send(msg)
+    return e500 "No get logic yet"
+
 
 module.exports = {startServer}

--- a/server/server.coffee
+++ b/server/server.coffee
@@ -166,9 +166,11 @@ startServer = (params) ->
       res.status(200).send(status)
 
   app.get '/plugin/register/custom', farm, (req, res) ->
+    e400 = (msg) -> res.status(400).send(msg)
     e501 = (msg) -> res.status(501).send(msg)
-    console.log(req)
-    return e501 "No get logic yet"
-
+    return e501 "No register module" unless custom
+    custom.get (err,status) ->
+      return e400 status if err
+      res.status(200).send(status)
 
 module.exports = {startServer}

--- a/server/server.coffee
+++ b/server/server.coffee
@@ -161,7 +161,9 @@ startServer = (params) ->
     return e400 "Missing context" unless context =req.body.context
     console.log('custom post',{context,data,custom})
     return e501 "No register module" unless custom
-    return await custom.post(data)
+    custom.post data, (err, status) ->
+      return e400 status if err
+      res.status(200).send(status)
 
   app.get '/plugin/register/custom', farm, (req, res) ->
     e501 = (msg) -> res.status(501).send(msg)

--- a/server/server.coffee
+++ b/server/server.coffee
@@ -154,7 +154,7 @@ startServer = (params) ->
   fs.readFile "#{argv.status}/register.js", 'utf8', (err, module) ->
     custom = await import("data:text/javascript;base64,#{btoa(module)}")
 
-  app.post '/plugin/register/custom', farm, (req, res) ->
+  app.post '/plugin/register/custom', owner, farm, (req, res) ->
     e400 = (msg) -> res.status(400).send(msg)
     e501 = (msg) -> res.status(501).send(msg)
     return e400 "Missing data" unless data = req.body.data
@@ -165,12 +165,12 @@ startServer = (params) ->
       return e400 status if err
       res.status(200).send(status)
 
-  app.get '/plugin/register/custom', farm, (req, res) ->
+  app.get '/plugin/register/custom', farm, owner, (req, res) ->
     e400 = (msg) -> res.status(400).send(msg)
     e501 = (msg) -> res.status(501).send(msg)
     return e501 "No register module" unless custom
     custom.get argv, (err,status) ->
-      return e400 status if err
+      return e400 err if err
       res.status(200).send(status)
 
 module.exports = {startServer}

--- a/server/server.coffee
+++ b/server/server.coffee
@@ -161,7 +161,7 @@ startServer = (params) ->
     return e400 "Missing context" unless context =req.body.context
     console.log('custom post',{context,data,custom})
     return e501 "No register module" unless custom
-    custom.post data, (err, status) ->
+    custom.post argv, data, (err, status) ->
       return e400 status if err
       res.status(200).send(status)
 
@@ -169,7 +169,7 @@ startServer = (params) ->
     e400 = (msg) -> res.status(400).send(msg)
     e501 = (msg) -> res.status(501).send(msg)
     return e501 "No register module" unless custom
-    custom.get (err,status) ->
+    custom.get argv, (err,status) ->
       return e400 status if err
       res.status(200).send(status)
 


### PR DESCRIPTION
Here we propose a third style of Registration, "custom", to join the existing "owner" and "delegate" versions. This is in support of a proposal described in wiki:
http://ward.asia.wiki.org/custom-registration-workflow.html

The wiki documentation describes a collaboration between a community leader and the service operators. This pull request represents additional enabling work by the federated wiki developers required to enable the workflow to progress without further enhancement of core javascript or standard plugins on a case by case basis.