### PR TITLE
Send whole request, not just optional param to adapter

### DIFF
--- a/server/server.coffee
+++ b/server/server.coffee
@@ -169,7 +169,7 @@ startServer = (params) ->
     e400 = (msg) -> res.status(400).send(msg)
     e501 = (msg) -> res.status(501).send(msg)
     return e501 "No register module" unless custom
-    custom.get argv, req.query.domain, (err,status) ->
+    custom.get argv, req, (err,status) ->
       return e400 err if err
       res.status(200).send(status)
 


### PR DESCRIPTION
You said to add the param in as the last parameter in chat... but I don't know enough coffeescript, and I don't want to mess up the function that's being defined there.